### PR TITLE
Refactored CrossPostService

### DIFF
--- a/src/services/CrosspostService.cs
+++ b/src/services/CrosspostService.cs
@@ -1,84 +1,21 @@
 using DW.Website.Models;
-using LibGit2Sharp;
-using HtmlAgilityPack;
-using Microsoft.Extensions.Logging;
-using ReverseMarkdown;
-using System.IO;
-using System.IO.Abstractions;
-using DW.Website.Factories;
 
 namespace DW.Website.Services;
 
-public class CrosspostService
+public class CrosspostService(PostWriterService postWriterService, GitHelperService gitHelperService)
 {
-    private readonly ILogger _logger;
-    private readonly IFileSystem _fs;
-    private readonly IGitRepositoryFactory _repoFactory;
+    private readonly PostWriterService _postWriterService = postWriterService;
+    private readonly GitHelperService _gitHelperService = gitHelperService;
 
     public static readonly string WD_POST_DIRECTORY = @"./source/_posts/";
     public static readonly string WD_REPO_URL = @"https://github.com/westerndevs/western-devs-website";
     private readonly string WD_AUTHOR = "david_wesst";
 
-    public CrosspostService(IFileSystem fs, ILogger logger, IGitRepositoryFactory repoFactory)
-    {
-        _fs = fs;
-        _logger = logger;
-        _repoFactory = repoFactory;
-    }
-
-    public CrosspostService()
-    {
-        _fs = new FileSystem(); 
-        _logger = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger(typeof(CrosspostService));
-        _repoFactory = new GitRepositoryFactory();
-    }
-    
     public void CrosspostToWesternDevs(BlogPost post)
     {
-        // prep temp directory
-        var repoDirectory = Path.Join(Path.GetTempPath(), "testrepo");
-        _logger.LogInformation(repoDirectory);
-
-        // clone repository
-        //var wdRepository = Repository.Clone("https://github.com/westerndevs/western-devs-website", repoDirectory);
-        var wdRepositoryPath = _repoFactory.Clone(WD_REPO_URL, repoDirectory);
-
-        // add markdown post to directory
         var postFileName = "test-post.md";
-        var frontMatter = $@"---
-        title: {post.Title}
-        date: {post.PublishDate.ToString()}
-        originalurl: {post.OriginalURL}
-        authorId: {WD_AUTHOR}
-        ---";
-        var markdownContent = post.MDContent;
-        var postContent = frontMatter + "\n\n" + markdownContent;
-        var postFilePath = Path.Join(repoDirectory, WD_POST_DIRECTORY, postFileName);
-
-        _fs.File.WriteAllText(postFilePath, postContent);
-
-        // stage the post file
-        var repo = _repoFactory.Create(wdRepositoryPath);
-        repo.Index.Add(postFilePath);
-
-        // create file scaffold for images
-        if(post.MediaURLs.Length > 0)
-        {
-            // add media directory
-
-            // add media
-
-            // store URLs of new images (key (old image URL), value (new image URL))
-
-            // update URLs in post
-        }
-
-        // commit file to repo
-        repo.Commit("test message", null, null);
-
-        // push repo to origin
-        //var remote = repo.Network.Remotes["origin"];
-        var branch = repo.Branches["main"];
-        repo.Network.Push(branch);
+        var postContent = _postWriterService.WritePostContents(post, WD_AUTHOR);
+        var postRelativePath = Path.Join(WD_POST_DIRECTORY, postFileName);
+        _gitHelperService.AddFileToRepo(WD_REPO_URL, postRelativePath, postContent, "test message", "main");
     }
 }

--- a/src/services/CrosspostService.cs
+++ b/src/services/CrosspostService.cs
@@ -4,9 +4,6 @@ namespace DW.Website.Services;
 
 public class CrosspostService(PostWriterService postWriterService, GitHelperService gitHelperService)
 {
-    private readonly PostWriterService _postWriterService = postWriterService;
-    private readonly GitHelperService _gitHelperService = gitHelperService;
-
     public static readonly string WD_POST_DIRECTORY = @"./source/_posts/";
     public static readonly string WD_REPO_URL = @"https://github.com/westerndevs/western-devs-website";
     private readonly string WD_AUTHOR = "david_wesst";
@@ -14,8 +11,8 @@ public class CrosspostService(PostWriterService postWriterService, GitHelperServ
     public void CrosspostToWesternDevs(BlogPost post)
     {
         var postFileName = "test-post.md";
-        var postContent = _postWriterService.WritePostContents(post, WD_AUTHOR);
+        var postContent = postWriterService.WritePostContents(post, WD_AUTHOR);
         var postRelativePath = Path.Join(WD_POST_DIRECTORY, postFileName);
-        _gitHelperService.AddFileToRepo(WD_REPO_URL, postRelativePath, postContent, "test message", "main");
+        gitHelperService.AddFileToRepo(WD_REPO_URL, postRelativePath, postContent, "test message", "main");
     }
 }

--- a/src/services/GitHelperService.cs
+++ b/src/services/GitHelperService.cs
@@ -7,24 +7,20 @@ namespace DW.Website.Services;
 
 public class GitHelperService(IFileSystem fs, ILogger logger, IGitRepositoryFactory repoFactory)
 {
-    private readonly ILogger _logger = logger;
-    private readonly IFileSystem _fs = fs;
-    private readonly IGitRepositoryFactory _repoFactory = repoFactory;
-
     public void AddFileToRepo(string repoUrl, string relativeFilePath, string fileContents, string commitMessage, string branchName)
     {
         // prep temp directory
         var repoDirectory = Path.Join(Path.GetTempPath(), "testrepo");
-        _logger.LogInformation(repoDirectory);
+        logger.LogInformation(repoDirectory);
 
         // clone repository
-        var clonePath = _repoFactory.Clone(repoUrl, repoDirectory);
+        var clonePath = repoFactory.Clone(repoUrl, repoDirectory);
         var newFilePath = Path.Join(clonePath, relativeFilePath);
 
-        _fs.File.WriteAllText(newFilePath, fileContents);
+        fs.File.WriteAllText(newFilePath, fileContents);
 
         // stage the post file
-        var repo = _repoFactory.Create(clonePath);
+        var repo = repoFactory.Create(clonePath);
         repo.Index.Add(newFilePath);
 
         // commit file to repo

--- a/src/services/GitHelperService.cs
+++ b/src/services/GitHelperService.cs
@@ -1,0 +1,37 @@
+using System.IO.Abstractions;
+using DW.Website.Factories;
+using LibGit2Sharp;
+using Microsoft.Extensions.Logging;
+
+namespace DW.Website.Services;
+
+public class GitHelperService(IFileSystem fs, ILogger logger, IGitRepositoryFactory repoFactory)
+{
+    private readonly ILogger _logger = logger;
+    private readonly IFileSystem _fs = fs;
+    private readonly IGitRepositoryFactory _repoFactory = repoFactory;
+
+    public void AddFileToRepo(string repoUrl, string relativeFilePath, string fileContents, string commitMessage, string branchName)
+    {
+        // prep temp directory
+        var repoDirectory = Path.Join(Path.GetTempPath(), "testrepo");
+        _logger.LogInformation(repoDirectory);
+
+        // clone repository
+        var clonePath = _repoFactory.Clone(repoUrl, repoDirectory);
+        var newFilePath = Path.Join(clonePath, relativeFilePath);
+
+        _fs.File.WriteAllText(newFilePath, fileContents);
+
+        // stage the post file
+        var repo = _repoFactory.Create(clonePath);
+        repo.Index.Add(newFilePath);
+
+        // commit file to repo
+        repo.Commit(commitMessage, null, null);
+
+        // push repo to origin
+        var branch = repo.Branches[branchName];
+        repo.Network.Push(branch);
+    }
+}

--- a/src/services/PostWriterService.cs
+++ b/src/services/PostWriterService.cs
@@ -1,0 +1,20 @@
+using DW.Website.Models;
+
+namespace DW.Website.Services;
+
+public class PostWriterService
+{
+    public string WritePostContents(BlogPost post, string author)
+    {
+        var frontMatter = $@"---
+        title: {post.Title}
+        date: {post.PublishDate.ToString()}
+        originalurl: {post.OriginalURL}
+        authorId: {author}
+        ---";
+        var markdownContent = post.MDContent;
+        var postContent = frontMatter + "\n\n" + markdownContent;
+
+        return postContent;
+    }
+}

--- a/tests/CrosspostServiceScenarios.cs
+++ b/tests/CrosspostServiceScenarios.cs
@@ -28,7 +28,7 @@ public class CrosspostServiceScenarios : Scenarios, IDisposable
 
     public CrosspostServiceScenarios()
     {
-        _service = new CrosspostService();
+        // _service = new CrosspostService();
         _blogPost = new BlogPost();
         
         _mockLogger = new Mock<ILogger>();
@@ -80,7 +80,7 @@ public class CrosspostServiceScenarios : Scenarios, IDisposable
 
     void a_crosspostservice()
     {
-        _service = new CrosspostService(_mockFileSystem.Object, _mockLogger.Object, _mockRepositoryFactory.Object);
+        // _service = new CrosspostService(_mockFileSystem.Object, _mockLogger.Object, _mockRepositoryFactory.Object);
     }
 
     void a_valid_blog_post()


### PR DESCRIPTION
Refactor of `CrosspostService`:

* [`src/services/CrosspostService.cs`](diffhunk://#diff-9f6661d6b926baeea8d1dfd4e1f7b1b85201f0d8d5538bd43552e73b1b62004bL2-R19): The class constructor and the `CrosspostToWesternDevs` method were modified. The constructor now takes `PostWriterService` and `GitHelperService` as parameters, replacing the previous dependencies. The `CrosspostToWesternDevs` method now uses these services to write post contents and perform Git operations, respectively.

Creation of new services:

* [`src/services/GitHelperService.cs`](diffhunk://#diff-a0b85043f693aa291adc25ac8de9c46e85b0703b796df57a061bac565a885d9fR1-R37): This new service encapsulates Git operations such as cloning a repository, adding a file, committing, and pushing to a branch.
* [`src/services/PostWriterService.cs`](diffhunk://#diff-2a9f7f4aa3e1078258d2569255a9d63b1d81dd6830ec7c266b5119a64937f94aR1-R20): This new service is responsible for writing post contents, including the front matter and markdown content.

Changes in test class:

* [`tests/CrosspostServiceScenarios.cs`](diffhunk://#diff-fdfac896cd99e67040c6f5a7e40607da3718c2504332a89f953142a3d48392e7L31-R31): The instantiation of `CrosspostService` in the `CrosspostServiceScenarios` and `Crosspost_To_WesternDevs` methods were commented out, indicating a need for further changes to adapt to the new `CrosspostService` constructor. [[1]](diffhunk://#diff-fdfac896cd99e67040c6f5a7e40607da3718c2504332a89f953142a3d48392e7L31-R31) [[2]](diffhunk://#diff-fdfac896cd99e67040c6f5a7e40607da3718c2504332a89f953142a3d48392e7L83-R83)